### PR TITLE
Generate room number

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -53,3 +53,10 @@ liveSocket.connect()
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket
+
+window.addEventListener("phx:copy", (event) => {
+  let text = event.target.textContent; // Alternatively use an element or data tag!
+    navigator.clipboard.writeText(text).then(() => {
+    })
+  })
+  

--- a/lib/pong_web/live/home_live.ex
+++ b/lib/pong_web/live/home_live.ex
@@ -2,6 +2,12 @@ defmodule PongWeb.HomeLive do
   use PongWeb, :live_view
 
   def mount(_params, _session, socket) do
+    room_code = generate_code()
+    socket = assign(socket, :room_code, room_code)
     {:ok, socket, layout: false}
+  end
+
+  defp generate_code() do
+    :rand.uniform(900_000) + 100_000
   end
 end

--- a/lib/pong_web/live/home_live.html.heex
+++ b/lib/pong_web/live/home_live.html.heex
@@ -5,10 +5,10 @@
     <div class="p-6 bg-gray-800 rounded-lg">
       <div class="text-center">
         <p class="text-2xl font-semibold mb-4">Share Game</p>
-        <p class="text-xl mb-2">Room Code: <span id="room-code">ABC123</span></p>
+        <p class="text-xl mb-2">Room Code: <span id="room_code"><%= @room_code %></span></p>
         <button
           class="w-full bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded"
-          phx-click="copy_room_code"
+          phx-click={JS.dispatch("phx:copy", to: "#room_code")}
         >
           Copy Room Code
         </button>


### PR DESCRIPTION
## Issue addressed
Resolves: #21
See also: #1

## What?
Added number generating functionality to the home page. And the copy to clipboard button.

## Why?
The room numbers will be used for joing and identifying a game.

## How?
Implemented a random number function that takes a number between 100_000 and 999_999, on `mount`.
Used JS to copy the number to clipboard. From [this tutorial](https://fly.io/phoenix-files/copy-to-clipboard-with-phoenix-liveview/)

## Testing?
na

## Screenshots (optional)
(The number changes when i reload the page.)

https://github.com/user-attachments/assets/47dce09a-c691-418a-95eb-43269c0567e8

## Anything Else?
na