### PR TITLE
Implement multi-client paddle connection

### DIFF
--- a/lib/pong/application.ex
+++ b/lib/pong/application.ex
@@ -17,7 +17,8 @@ defmodule Pong.Application do
       # Start a worker by calling: Pong.Worker.start_link(arg)
       # {Pong.Worker, arg},
       # Start to serve requests, typically the last entry
-      PongWeb.Endpoint
+      PongWeb.Endpoint,
+      PongWeb.Presence
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/pong_web/channels/presence.ex
+++ b/lib/pong_web/channels/presence.ex
@@ -1,0 +1,11 @@
+defmodule PongWeb.Presence do
+  @moduledoc """
+  Provides presence tracking to channels and processes.
+
+  See the [`Phoenix.Presence`](https://hexdocs.pm/phoenix/Phoenix.Presence.html)
+  docs for more details.
+  """
+  use Phoenix.Presence,
+    otp_app: :pong,
+    pubsub_server: Pong.PubSub
+end

--- a/lib/pong_web/live/game_live.html.heex
+++ b/lib/pong_web/live/game_live.html.heex
@@ -6,9 +6,19 @@
       <div class="flex justify-center items-center h-full">
         <div
           id="player"
-          class="bg-white w-[1%] h-[20%] fixed top-0 left-0"
-          style={"left: 6.25%; top: #{@y_player}%"}
+          class="bg-white w-[1%] h-[20%] fixed top-0"
+          style={
+            "left: #{if @side == :left, do: "6.25%", else: "93.75%"}; top: #{@y_player}%"
+          }
           phx-hook="TrackClientCursor"
+        >
+        </div>
+        <div
+          id="opponent"
+          class="bg-white w-[1%] h-[20%] fixed top-0"
+          style={
+            "left: #{if @side == :left, do: "93.75%", else: "6.25%"}; top: #{@y_opponent}%"
+          }
         >
         </div>
         <div

--- a/lib/pong_web/router.ex
+++ b/lib/pong_web/router.ex
@@ -17,8 +17,8 @@ defmodule PongWeb.Router do
   scope "/", PongWeb do
     pipe_through :browser
 
-    live "/", HomeLive, :home
-    live "/game", GameLive, :game
+    live "/", HomeLive
+    live "/:game_id", GameLive
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
## Issue addressed
Resolves: #26
See also: #1

## What?
Added the first real-time feature. When two brosers open the same
game id, they will be assigned to a paddle each, and see each other's
position in real time.

## Why?
na

## How?
- Used `mix phx.gen.presence`.
- Added logic to handle players joining a game.
- Added logic to share each player's position with each other.

## Testing?
na

## Screenshots (optional)

https://github.com/user-attachments/assets/a2cf793a-3720-45f0-a35c-ce07980e2b67


## Anything Else?
na