### PR TITLE
Implement multi-client ball and score connection

### DIFF
--- a/lib/pong/application.ex
+++ b/lib/pong/application.ex
@@ -18,7 +18,9 @@ defmodule Pong.Application do
       # {Pong.Worker, arg},
       # Start to serve requests, typically the last entry
       PongWeb.Endpoint,
-      PongWeb.Presence
+      PongWeb.Presence,
+      {Registry, keys: :unique, name: Pong.GameRegistry},
+      {DynamicSupervisor, strategy: :one_for_one, name: Pong.GameSupervisor}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/pong/game_server.ex
+++ b/lib/pong/game_server.ex
@@ -1,0 +1,280 @@
+defmodule Pong.GameServer do
+  use GenServer
+
+  # Public API
+
+  def start_link(game_id) do
+    GenServer.start_link(__MODULE__, %{game_id: game_id}, name: via_tuple(game_id))
+  end
+
+  defp via_tuple(game_id) do
+    {:via, Registry, {Pong.GameRegistry, game_id}}
+  end
+
+  def get_state(game_id) do
+    GenServer.call(via_tuple(game_id), :get_state)
+  end
+
+  # GenServer Callbacks
+
+  def init(state) do
+    initial_state = %{
+      game_id: state.game_id,
+      ball: %{x: 50, y: 50, vx: -0.25, vy: 0.0},
+      score: %{left: 0, right: 0},
+      timer_ref: nil
+    }
+
+    # Start the game loop
+    {:ok, schedule_tick(initial_state)}
+  end
+
+  def handle_info(:tick, state) do
+    # Update the game state
+    new_state = update_game_state(state)
+
+    # Broadcast the new state to clients
+    PongWeb.Endpoint.broadcast("game:#{state.game_id}", "game_state_update", %{
+      ball: new_state.ball,
+      score: new_state.score
+    })
+
+    # Schedule the next tick
+    {:noreply, schedule_tick(new_state)}
+  end
+
+  def handle_call(:get_state, _from, state) do
+    {:reply, state, state}
+  end
+
+  # Helper functions
+
+  defp schedule_tick(state) do
+    timer_ref = Process.send_after(self(), :tick, 10)
+    Map.replace(state, :timer_ref, timer_ref)
+  end
+
+  defp update_game_state(state) do
+    ball = state.ball
+    score = state.score
+
+    # Update ball position
+    ball_left_border_pos_current = ball.x
+    ball_top_border_pos_current = ball.y
+    ball_speed_x_current = ball.vx
+    ball_speed_y_current = ball.vy
+
+    ball_height = 1.25
+    # Assuming the ball is square
+    ball_width = 1.25
+
+    # Compute next positions
+    ball_left_border_next = ball_left_border_pos_current + ball_speed_x_current
+    ball_top_border_next = ball_top_border_pos_current + ball_speed_y_current
+    ball_bottom_border_next = ball_top_border_next + ball_height
+    ball_right_border_next = ball_left_border_next + ball_width
+    ball_vertical_middle = ball_top_border_next + ball_height / 2
+
+    # Paddle dimensions and positions
+    paddle_sector_sizes = [45, 10, 45]
+
+    # Retrieve paddle positions from Presence
+    paddles = get_paddle_positions(state.game_id)
+
+    # Left paddle
+    {left_paddle_top, left_paddle_left_border} =
+      case paddles.left do
+        # Default values if paddle position not available
+        nil -> {50, 6.25}
+        y_player -> {y_player, 6.25}
+      end
+
+    # Paddle width is 1%
+    left_paddle_right_border = left_paddle_left_border + 1
+
+    {left_paddle_top_sector_bottom_limit, left_paddle_middle_sector_bottom_limit,
+     left_paddle_bottom} =
+      paddle_sectors(left_paddle_top, paddle_sector_sizes)
+
+    # Right paddle
+    {right_paddle_top, right_paddle_left_border} =
+      case paddles.right do
+        # Default values if paddle position not available
+        nil -> {50, 93.75}
+        y_player -> {y_player, 93.75}
+      end
+
+    # Paddle width is 1%
+    right_paddle_right_border = right_paddle_left_border + 1
+
+    {right_paddle_top_sector_bottom_limit, right_paddle_middle_sector_bottom_limit,
+     right_paddle_bottom} =
+      paddle_sectors(right_paddle_top, paddle_sector_sizes)
+
+    # Check for collisions
+    collision_with_left_paddle =
+      float_in_range?(ball_left_border_next, left_paddle_left_border, left_paddle_right_border) and
+        float_in_range?(ball_vertical_middle, left_paddle_top, left_paddle_bottom)
+
+    collision_with_right_paddle =
+      float_in_range?(ball_right_border_next, right_paddle_left_border, right_paddle_right_border) and
+        float_in_range?(ball_vertical_middle, right_paddle_top, right_paddle_bottom)
+
+    {ball_speed_x_next, ball_speed_y_next} =
+      cond do
+        collision_with_left_paddle ->
+          handle_paddle_collision(
+            ball_vertical_middle,
+            left_paddle_top,
+            {left_paddle_top_sector_bottom_limit, left_paddle_middle_sector_bottom_limit,
+             left_paddle_bottom},
+            ball_speed_x_current,
+            ball_speed_y_current
+          )
+
+        collision_with_right_paddle ->
+          handle_paddle_collision(
+            ball_vertical_middle,
+            right_paddle_top,
+            {right_paddle_top_sector_bottom_limit, right_paddle_middle_sector_bottom_limit,
+             right_paddle_bottom},
+            ball_speed_x_current,
+            ball_speed_y_current
+          )
+
+        ball_top_border_next < 0 ->
+          {ball_speed_x_current, -ball_speed_y_current}
+
+        ball_bottom_border_next > 100 ->
+          {ball_speed_x_current, -ball_speed_y_current}
+
+        true ->
+          {ball_speed_x_current, ball_speed_y_current}
+      end
+
+    # Check for scoring and respawn ball if necessary
+    {score, ball} =
+      check_score_and_respawn_ball(
+        ball_left_border_next,
+        ball_right_border_next,
+        score.left,
+        score.right,
+        ball_speed_x_next,
+        ball_speed_y_next,
+        ball_top_border_next
+      )
+
+    new_ball = %{
+      x: ball.x,
+      y: ball.y,
+      vx: ball.vx,
+      vy: ball.vy
+    }
+
+    %{state | ball: new_ball, score: score}
+  end
+
+  # Helper functions
+
+  defp paddle_sectors(paddle_top, paddle_sector_sizes) do
+    paddle_sector_sizes_absolute = Enum.map(paddle_sector_sizes, &(&1 * 20 / 100))
+    paddle_top_sector_bottom_limit = paddle_top + Enum.at(paddle_sector_sizes_absolute, 0)
+
+    paddle_middle_sector_bottom_limit =
+      paddle_top_sector_bottom_limit + Enum.at(paddle_sector_sizes_absolute, 1)
+
+    paddle_bottom = paddle_middle_sector_bottom_limit + Enum.at(paddle_sector_sizes_absolute, 2)
+
+    {paddle_top_sector_bottom_limit, paddle_middle_sector_bottom_limit, paddle_bottom}
+  end
+
+  defp handle_paddle_collision(
+         ball_vertical_middle,
+         paddle_top,
+         {paddle_top_sector_bottom_limit, paddle_middle_sector_bottom_limit, paddle_bottom},
+         ball_speed_x_current,
+         ball_speed_y_current
+       ) do
+    cond do
+      float_in_range?(ball_vertical_middle, paddle_top, paddle_top_sector_bottom_limit) ->
+        {-ball_speed_x_current, ball_speed_x_current}
+
+      float_in_range?(
+        ball_vertical_middle,
+        paddle_top_sector_bottom_limit,
+        paddle_middle_sector_bottom_limit
+      ) ->
+        {-ball_speed_x_current, ball_speed_y_current}
+
+      float_in_range?(ball_vertical_middle, paddle_middle_sector_bottom_limit, paddle_bottom) ->
+        {-ball_speed_x_current, -ball_speed_x_current}
+
+      true ->
+        {ball_speed_x_current, ball_speed_y_current}
+    end
+  end
+
+  defp check_score_and_respawn_ball(
+         ball_left_border_next,
+         ball_right_border_next,
+         left_player_current_points,
+         right_player_current_points,
+         _ball_speed_x_next,
+         _ball_speed_y_next,
+         _ball_top_border_next
+       ) do
+    cond do
+      # Ball went past the right boundary
+      ball_left_border_next > 100 ->
+        {%{left: left_player_current_points + 1, right: right_player_current_points},
+         %{x: 50, y: 50, vx: 25 / 100, vy: 0 / 100}}
+
+      # Ball went past the left boundary
+      ball_right_border_next < 0 ->
+        {%{left: left_player_current_points, right: right_player_current_points + 1},
+         %{x: 50, y: 50, vx: -25 / 100, vy: 0 / 100}}
+
+      true ->
+        {%{left: left_player_current_points, right: right_player_current_points},
+         %{
+           x: ball_left_border_next,
+           y: _ball_top_border_next,
+           vx: _ball_speed_x_next,
+           vy: _ball_speed_y_next
+         }}
+    end
+  end
+
+  defp float_in_range?(float, min, max) do
+    float >= min and float <= max
+  end
+
+  # Function to get paddle positions from Presence
+  defp get_paddle_positions(game_id) do
+    presences = PongWeb.Presence.list("game:#{game_id}")
+
+    left_paddle =
+      presences
+      |> Enum.find(fn
+        {_, %{metas: [%{side: :left}]}} -> true
+        _ -> false
+      end)
+      |> case do
+        {_, %{metas: [%{y_player: y}]}} -> y
+        _ -> nil
+      end
+
+    right_paddle =
+      presences
+      |> Enum.find(fn
+        {_, %{metas: [%{side: :right}]}} -> true
+        _ -> false
+      end)
+      |> case do
+        {_, %{metas: [%{y_player: y}]}} -> y
+        _ -> nil
+      end
+
+    %{left: left_paddle, right: right_paddle}
+  end
+end

--- a/lib/pong_web/live/game_live.ex
+++ b/lib/pong_web/live/game_live.ex
@@ -1,13 +1,21 @@
 defmodule PongWeb.GameLive do
   use PongWeb, :live_view
+  alias Pong.GameServer
   alias PongWeb.Presence
 
   def mount(%{"game_id" => game_id}, _session, socket) do
-    # Start the game tick if the socket is connected
-    if connected?(socket), do: :timer.send_interval(10, self(), :tick)
+    # Start the GameServer for this game_id if it doesn't exist
+    case DynamicSupervisor.start_child(Pong.GameSupervisor, {GameServer, game_id}) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+      {:error, reason} -> {:stop, reason}
+    end
 
-    # Generate a unique player ID using :crypto and Base modules
+    # Generate a unique player ID
     player_id = :crypto.strong_rand_bytes(16) |> Base.encode16(case: :lower)
+
+    # Get the current game state from the GameServer
+    game_state = GameServer.get_state(game_id)
 
     # Assign initial values to the socket
     socket =
@@ -20,22 +28,19 @@ defmodule PongWeb.GameLive do
       |> assign(:y_opponent, 50)
       # Default side until assigned
       |> assign(:side, :spectator)
-      # Initial ball state
-      |> assign(:ball, %{x: 50, y: 50, vx: -0.25, vy: 0.0})
-      # Initial score
-      |> assign(:score, %{left: 0, right: 0})
+      # Assign the game state from the GameServer
+      |> assign(:ball, game_state.ball)
+      |> assign(:score, game_state.score)
 
     if connected?(socket) do
       # Subscribe to the game topic for PubSub
       PongWeb.Endpoint.subscribe("game:#{game_id}")
 
       # Track the player's presence in the game
-      Presence.track(self(), "game:#{game_id}", player_id, %{})
-
-      # Get the current list of presences to assign sides
-      presences = Presence.list("game:#{game_id}")
-      side = assign_side(presences, player_id)
-      socket = assign(socket, :side, side)
+      Presence.track(self(), "game:#{game_id}", player_id, %{
+        y_player: socket.assigns.y_player,
+        side: socket.assigns.side
+      })
     end
 
     {:ok, socket, layout: false}
@@ -49,76 +54,23 @@ defmodule PongWeb.GameLive do
     # Update own paddle position
     socket = assign(socket, :y_player, y)
 
+    # Update presence metadata
+    Presence.update(self(), "game:#{game_id}", player_id, %{
+      y_player: y,
+      side: side
+    })
+
     # Broadcast the new position to other clients
-    PongWeb.Endpoint.broadcast_from(self(), "game:#{game_id}", "update_paddle", %{
-      player_id: player_id,
-      side: side,
-      y: y
+    PongWeb.Endpoint.broadcast_from(self(), "game:#{game_id}", "paddle_update", %{
+      "player_id" => player_id,
+      "side" => side,
+      "y" => y
     })
 
     {:noreply, socket}
   end
 
-  def handle_info(:tick, socket) do
-    %{
-      x: ball_left_border_pos_current,
-      y: ball_top_border_pos_current,
-      vx: ball_speed_x_current,
-      vy: ball_speed_y_current
-    } = socket.assigns.ball
-
-    %{left: left_player_current_points, right: right_player_current_points} = socket.assigns.score
-
-    ball_height = 1.25
-    ball_vertical_middle = ball_top_border_pos_current + ball_height / 2
-
-    paddel_top = socket.assigns.y_player
-    paddel_sector_sizes = [45, 10, 45]
-
-    {paddel_top_sector_bottom_limit, paddel_middle_sector_bottom_limit, paddel_bottom} =
-      paddel_sectors(paddel_top, paddel_sector_sizes)
-
-    paddel_left_border = 6.25
-    paddel_right_border = paddel_left_border + 1
-
-    ball_left_border_next = ball_left_border_pos_current + ball_speed_x_current
-    ball_top_border_next = ball_top_border_pos_current + ball_speed_y_current
-    ball_bottom_border_next = ball_top_border_next + ball_height
-
-    {ball_speed_x_next, ball_speed_y_next} =
-      cond do
-        float_in_range?(ball_left_border_next, paddel_left_border, paddel_right_border) ->
-          handle_paddle_collision(
-            ball_vertical_middle,
-            paddel_top,
-            {paddel_top_sector_bottom_limit, paddel_middle_sector_bottom_limit, paddel_bottom},
-            ball_speed_x_current,
-            ball_speed_y_current
-          )
-
-        ball_top_border_next < 0 ->
-          {ball_speed_x_current, -ball_speed_y_current}
-
-        ball_bottom_border_next > 100 ->
-          {ball_speed_x_current, -ball_speed_y_current}
-
-        true ->
-          {ball_speed_x_current, ball_speed_y_current}
-      end
-
-    {score, ball} =
-      check_score_and_respawn_ball(
-        ball_left_border_next,
-        left_player_current_points,
-        right_player_current_points,
-        ball_speed_x_next,
-        ball_speed_y_next,
-        ball_top_border_next
-      )
-
-    {:noreply, assign(socket, ball: ball, score: score)}
-  end
-
+  # Handle presence updates to assign sides
   def handle_info(
         %Phoenix.Socket.Broadcast{
           event: "presence_diff",
@@ -131,8 +83,9 @@ defmodule PongWeb.GameLive do
     {:noreply, assign(socket, :side, side)}
   end
 
-  def handle_info(%Phoenix.Socket.Broadcast{event: "update_paddle", payload: payload}, socket) do
-    %{player_id: player_id, side: side, y: y} = payload
+  # Handle paddle updates from other players
+  def handle_info(%Phoenix.Socket.Broadcast{event: "paddle_update", payload: payload}, socket) do
+    %{"player_id" => player_id, "side" => side, "y" => y} = payload
 
     if player_id != socket.assigns.player_id and opposite_side?(socket.assigns.side, side) do
       {:noreply, assign(socket, :y_opponent, y)}
@@ -141,6 +94,15 @@ defmodule PongWeb.GameLive do
     end
   end
 
+  # Handle game state updates from the GameServer
+  def handle_info(
+        %Phoenix.Socket.Broadcast{event: "game_state_update", payload: new_state},
+        socket
+      ) do
+    {:noreply, assign(socket, ball: new_state.ball, score: new_state.score)}
+  end
+
+  # Helper functions
   defp opposite_side?(:left, :right), do: true
   defp opposite_side?(:right, :left), do: true
   defp opposite_side?(_, _), do: false
@@ -149,7 +111,7 @@ defmodule PongWeb.GameLive do
     player_ids = Map.keys(presences) |> Enum.sort()
 
     cond do
-      player_ids == [player_id] ->
+      length(player_ids) == 1 ->
         :left
 
       length(player_ids) >= 2 ->
@@ -164,75 +126,5 @@ defmodule PongWeb.GameLive do
       true ->
         :spectator
     end
-  end
-
-  defp paddel_sectors(paddel_top, paddel_sector_sizes) do
-    paddel_sector_sizes_absolute = Enum.map(paddel_sector_sizes, &(&1 * 20 / 100))
-    paddel_top_sector_bottom_limit = paddel_top + Enum.at(paddel_sector_sizes_absolute, 0)
-
-    paddel_middle_sector_bottom_limit =
-      paddel_top_sector_bottom_limit + Enum.at(paddel_sector_sizes_absolute, 1)
-
-    paddel_bottom = paddel_middle_sector_bottom_limit + Enum.at(paddel_sector_sizes_absolute, 2)
-
-    {paddel_top_sector_bottom_limit, paddel_middle_sector_bottom_limit, paddel_bottom}
-  end
-
-  defp handle_paddle_collision(
-         ball_vertical_middle,
-         paddel_top,
-         {paddel_top_sector_bottom_limit, paddel_middle_sector_bottom_limit, paddel_bottom},
-         ball_speed_x_current,
-         ball_speed_y_current
-       ) do
-    cond do
-      float_in_range?(ball_vertical_middle, paddel_top, paddel_top_sector_bottom_limit) ->
-        {-ball_speed_x_current, ball_speed_x_current}
-
-      float_in_range?(
-        ball_vertical_middle,
-        paddel_top_sector_bottom_limit,
-        paddel_middle_sector_bottom_limit
-      ) ->
-        {-ball_speed_x_current, ball_speed_y_current}
-
-      float_in_range?(ball_vertical_middle, paddel_middle_sector_bottom_limit, paddel_bottom) ->
-        {-ball_speed_x_current, -ball_speed_x_current}
-
-      true ->
-        {ball_speed_x_current, ball_speed_y_current}
-    end
-  end
-
-  defp check_score_and_respawn_ball(
-         ball_left_border_next,
-         left_player_current_points,
-         right_player_current_points,
-         ball_speed_x_next,
-         ball_speed_y_next,
-         ball_top_border_next
-       ) do
-    cond do
-      ball_left_border_next > 100 ->
-        {%{left: left_player_current_points + 1, right: right_player_current_points},
-         %{x: 50, y: 50, vx: 25 / 100, vy: 0 / 100}}
-
-      ball_left_border_next < 0 ->
-        {%{left: left_player_current_points, right: right_player_current_points + 1},
-         %{x: 50, y: 50, vx: -25 / 100, vy: 0 / 100}}
-
-      true ->
-        {%{left: left_player_current_points, right: right_player_current_points},
-         %{
-           x: ball_left_border_next,
-           y: ball_top_border_next,
-           vx: ball_speed_x_next,
-           vy: ball_speed_y_next
-         }}
-    end
-  end
-
-  defp float_in_range?(float, min, max) do
-    float >= min and float <= max
   end
 end


### PR DESCRIPTION
## Issue addressed
Resolves: #1, #30, #31
See also: na

## What?
Implemented the logic to show the same ball position and score on multiple clients.

## Why?
This were the last features required to complete the MVP.

## How?
![image](https://github.com/user-attachments/assets/39e71597-1a0e-4e4f-81df-7d491ee85fff)
The browsers retrieve the position of the ball and the score from the GenServer by handling a tick message broadcast from the server. The position of the players is shared directly between browsers using PongWeb.Endpoint.broadcast_from.

Right after broadcasting the paddle position to the other browser, they update their paddle position in the presence using Presence.update.

The GenServer retrieves the position of each player from the presence using PongWeb.Presence.list so it can calculate the position of the ball or add a point to the scoreboard in the next tick (server ticks every 10 ms) .

The position of the ball and the scores are stored on the GenServer.

## Testing?
na, will do on a future PR.

## Screenshots (optional)
https://github.com/user-attachments/assets/6a74893e-0fe8-44dc-bc15-52e128fb51c5

## Anything Else?
This works but there are no tests, the code and the architecture are ugly, and some warnings are unresolved. My next PR will be a refactor.